### PR TITLE
Add Sovran to Freedom Store

### DIFF
--- a/altstore-source.json
+++ b/altstore-source.json
@@ -29,7 +29,7 @@
       ],
       "versions": [
         {
-          "downloadURL": "https://productionresultssa14.blob.core.windows.net/actions-results/5e5112d6-59f3-493c-b4bb-20185229f8cc/workflow-job-run-4df39c96-f8a5-5acc-8e7e-0efbfe3123e2/artifacts/d18fd9248dd5688be2f49d28b00a57b126e67163ad332401d60faaa717f4146d.zip?rscd=attachment%3B+filename%3D%220130109b-8a39-481d-8c18-2b856811bd5d.zip%22&se=2025-06-10T07%3A11%3A13Z&sig=vINQcoL9UGCRj57JGNFQ8bTaUUkiOt8rVS570ppvd5Q%3D&ske=2025-06-10T15%3A44%3A49Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-06-10T03%3A44%3A49Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-05-05&sp=r&spr=https&sr=b&st=2025-06-10T07%3A01%3A08Z&sv=2025-05-05",
+          "downloadURL": "https://sovran.money/ios/releases/0130109b-8a39-481d-8c18-2b856811bd5d/",
           "size": 25400000,
           "version": "0.0.20",
           "buildVersion": "1",


### PR DESCRIPTION
Please double check I've done this right. First time doing any altstore stuff. I used `https://altstudio.app` for generating the JSON.